### PR TITLE
Bug Fixes

### DIFF
--- a/Main/src/main/java/pl/xayanix/bbce/bukkit/BukkitBringBackChatEdit.java
+++ b/Main/src/main/java/pl/xayanix/bbce/bukkit/BukkitBringBackChatEdit.java
@@ -22,7 +22,7 @@ public class BukkitBringBackChatEdit extends JavaPlugin implements PluginMessage
 
 
     public void onPluginMessageReceived(String s, Player player, byte[] bytes) {
-        if(s.equalsIgnoreCase("nscore:chatsign")){
+        if(s.equalsIgnoreCase("bbce:chatsign")){
             ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
             byteArrayInputStream.skip(2);
             try {

--- a/Main/src/main/java/pl/xayanix/bbce/bungee/listeners/ChatListener.java
+++ b/Main/src/main/java/pl/xayanix/bbce/bungee/listeners/ChatListener.java
@@ -4,6 +4,7 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.ChatEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -13,7 +14,7 @@ import java.io.DataOutputStream;
 */
 public class ChatListener implements Listener {
 
-    @EventHandler(priority = (byte) 999)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onChat(ChatEvent event){
         if(event.isCommand() || event.isCancelled() || event.isProxyCommand()) return;
 


### PR DESCRIPTION
- Fixes a bug where the Bukkit plugin was checking for "nscore:chatsign" instead of "bbce:chatsign".
- Fixes a bug in the Bungee plugin where ChatEvent was being ran before messages were modified.
  - The custom event priority value of 999 did not seem to affect the order of the event execution.