### PR TITLE
Fixed bug on 1.17 servers

### DIFF
--- a/Main/src/main/resources/plugin.yml
+++ b/Main/src/main/resources/plugin.yml
@@ -2,3 +2,4 @@ name: BringBackChatEdit
 version: b1
 author: Xayanix
 main: pl.xayanix.bbce.bukkit.BukkitBringBackChatEdit
+libraries: [commons-io:commons-io:2.11.0]


### PR DESCRIPTION
- Added commons-io to the plugin.yml because on 1.17 servers, NoClassDefFoundError would be spammed and chat would not send.